### PR TITLE
*[hotfix] - this fixes an issue where records are inserting themselve…

### DIFF
--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -893,7 +893,8 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                               rowRelateVal.filter(
                                  (v) =>
                                     v == updatedVals.id ||
-                                    v.id == updatedVals.id
+                                    v.id == updatedVals.id ||
+                                    v[PK] == updatedVals.id
                               ).length < 1 &&
                               isRelated(updateRelateVal, d.id, PK)
                            ) {
@@ -902,11 +903,12 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                               updateItemData[f.relationName()] = rowRelateVal;
                               updateItemData[f.columnName] = updateItemData[
                                  f.relationName()
-                              ].map((v) => v.id || v);
+                              ].map((v) => v.id || v[PK] || v);
                            } else if (
                               !Array.isArray(rowRelateVal) &&
                               (rowRelateVal != updatedVals.id ||
-                                 rowRelateVal.id != updatedVals.id) &&
+                                 rowRelateVal.id != updatedVals.id ||
+                                 rowRelateVal[PK] != updatedVals.id) &&
                               isRelated(updateRelateVal, d.id, PK)
                            ) {
                               updateItemData[f.relationName()] = updatedVals;

--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -1113,20 +1113,24 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                      if (
                         Array.isArray(rowRelateVal) &&
                         rowRelateVal.filter(
-                           (v) => v == values.id || v.id == values.id
+                           (v) =>
+                              v == values.id ||
+                              v.id == values.id ||
+                              v[PK] == values.id
                         ).length > 0 &&
                         !isRelated(updateRelateVal, d.id, PK)
                      ) {
                         updateItemData[f.relationName()] = rowRelateVal.filter(
-                           (v) => (v.id || v) != values.id
+                           (v) => (v.id || v || v[PK]) != values.id
                         );
                         updateItemData[f.columnName] = updateItemData[
                            f.relationName()
-                        ].map((v) => v.id || v);
+                        ].map((v) => v.id || v || v[PK]);
                      } else if (
                         !Array.isArray(rowRelateVal) &&
                         (rowRelateVal == values.id ||
-                           rowRelateVal.id == values.id) &&
+                           rowRelateVal.id == values.id ||
+                           rowRelatedVal[PK] == values.id) &&
                         !isRelated(updateRelateVal, d.id, PK)
                      ) {
                         updateItemData[f.relationName()] = null;
@@ -1141,11 +1145,18 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                         // update relate data
                         if (
                            rowRelateVal.filter(
-                              (v) => v == values.id || v.id == values.id
+                              (v) =>
+                                 v == values.id ||
+                                 v.id == values.id ||
+                                 v[PK] == values.id
                            ).length > 0
                         ) {
                            rowRelateVal.forEach((v, index) => {
-                              if (v == values.id || v.id == values.id)
+                              if (
+                                 v == values.id ||
+                                 v.id == values.id ||
+                                 v[PK] == values.id
+                              )
                                  rowRelateVal[index] = values;
                            });
                         }
@@ -1157,11 +1168,12 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                         updateItemData[f.relationName()] = rowRelateVal;
                         updateItemData[f.columnName] = updateItemData[
                            f.relationName()
-                        ].map((v) => v.id || v);
+                        ].map((v) => v.id || v || v[PK]);
                      } else if (
                         !Array.isArray(rowRelateVal) &&
                         (rowRelateVal != values.id ||
-                           rowRelateVal.id != values.id) &&
+                           rowRelateVal.id != values.id ||
+                           rowRelateVal[PK] != values.id) &&
                         isRelated(updateRelateVal, d.id, PK)
                      ) {
                         updateItemData[f.relationName()] = values;

--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -573,10 +573,17 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
       // if all off these pass reload the data using server side binding
       if (this.__reloadWheres && !this.settings.loadAll && shouldReloadData) {
          this.reloadData();
-      } else if (this.__reloadWheres && !this.settings.loadAll) {
-         // no need to filter the data because it was already filterted and not
-         // marked as shouldReloadData so just move on
-         return false;
+
+         // June 30, 2021 - James Duncan
+         // removing this because we were having issues with users working on the
+         // same record and the updates of a record would appear in a filtered
+         // data set would insert a new record in a filtered data set that it
+         // should have been filtered out of
+
+         // } else if (this.__reloadWheres && !this.settings.loadAll) {
+         //    // no need to filter the data because it was already filterted and not
+         //    // marked as shouldReloadData so just move on
+         //    return false;
       } else {
          // if the checks do not pass we filter the data in the data collection
          // using its parents current cursor because all the data in this child

--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -624,7 +624,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                   if (r[f.columnName].filter) {
                      // Array - isMultiple
                      found =
-                        r[f.colName].filter((data) => data.id == username)
+                        r[f.columnName].filter((data) => data.id == username)
                            .length > 0;
                   } else if (r[f.columnName] == username) {
                      found = true;

--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -1121,11 +1121,11 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                         !isRelated(updateRelateVal, d.id, PK)
                      ) {
                         updateItemData[f.relationName()] = rowRelateVal.filter(
-                           (v) => (v.id || v || v[PK]) != values.id
+                           (v) => (v.id || v[PK] || v) != values.id
                         );
                         updateItemData[f.columnName] = updateItemData[
                            f.relationName()
-                        ].map((v) => v.id || v || v[PK]);
+                        ].map((v) => v.id || v[PK] || v);
                      } else if (
                         !Array.isArray(rowRelateVal) &&
                         (rowRelateVal == values.id ||
@@ -1168,7 +1168,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                         updateItemData[f.relationName()] = rowRelateVal;
                         updateItemData[f.columnName] = updateItemData[
                            f.relationName()
-                        ].map((v) => v.id || v || v[PK]);
+                        ].map((v) => v.id || v[PK] || v);
                      } else if (
                         !Array.isArray(rowRelateVal) &&
                         (rowRelateVal != values.id ||
@@ -1370,6 +1370,9 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
             connectedFields &&
             connectedFields.length > 0
          ) {
+            // various PK name
+            let PK = connectedFields[0].object.PK();
+
             this.__dataCollection.find({}).forEach((d) => {
                let updateRelateVals = {};
 
@@ -1379,18 +1382,23 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
 
                   if (
                      Array.isArray(relateVal) &&
-                     relateVal.filter((v) => v == deleteId || v.id == deleteId)
-                        .length > 0
+                     relateVal.filter(
+                        (v) =>
+                           v == deleteId ||
+                           v.id == deleteId ||
+                           v[PK] == deleteId
+                     ).length > 0
                   ) {
                      updateRelateVals[f.relationName()] = relateVal.filter(
-                        (v) => (v.id || v) != deleteId
+                        (v) => (v.id || v[PK] || v) != deleteId
                      );
                      updateRelateVals[f.columnName] = updateRelateVals[
                         f.relationName()
-                     ].map((v) => v.id || v);
+                     ].map((v) => v.id || v[PK] || v);
                   } else if (
                      relateVal == deleteId ||
-                     relateVal.id == deleteId
+                     relateVal.id == deleteId ||
+                     relateVal[PK] == deleteId
                   ) {
                      updateRelateVals[f.relationName()] = null;
                      updateRelateVals[f.columnName] = null;

--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -1130,7 +1130,7 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
                         !Array.isArray(rowRelateVal) &&
                         (rowRelateVal == values.id ||
                            rowRelateVal.id == values.id ||
-                           rowRelatedVal[PK] == values.id) &&
+                           rowRelateVal[PK] == values.id) &&
                         !isRelated(updateRelateVal, d.id, PK)
                      ) {
                         updateItemData[f.relationName()] = null;

--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -566,24 +566,12 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
     * @param {bool} shouldReloadData - boolean that is passed if new data should be fetched from server
     */
    refreshLinkCursor(shouldReloadData = false) {
-      // check __reloadWheres for server side binding filters
-      // check to ensure that data collection is not marked as loadAll
-      // check to see if the data has been flagged as shouldReloadData because
-      // the data in a connected field has changed.
-      // if all off these pass reload the data using server side binding
-      if (this.__reloadWheres && !this.settings.loadAll && shouldReloadData) {
-         this.reloadData();
-
-         // June 30, 2021 - James Duncan
-         // removing this because we were having issues with users working on the
-         // same record and the updates of a record would appear in a filtered
-         // data set would insert a new record in a filtered data set that it
-         // should have been filtered out of
-
-         // } else if (this.__reloadWheres && !this.settings.loadAll) {
-         //    // no need to filter the data because it was already filterted and not
-         //    // marked as shouldReloadData so just move on
-         //    return false;
+      // Putting this back the way it was because the core issue was the data DataCollections
+      // were not getting udpates from the socket reponses because we didn't do lookups
+      // off of the PK when it was used.
+      if (this.__reloadWheres && !this.settings.loadAll) {
+         // no need to filter the data because it was already filterted
+         return false;
       } else {
          // if the checks do not pass we filter the data in the data collection
          // using its parents current cursor because all the data in this child

--- a/ABDataCollectionCore.js
+++ b/ABDataCollectionCore.js
@@ -1854,15 +1854,16 @@ module.exports = class ABDataCollectionCore extends ABMLClass {
          }
       }
 
+      let PK = fieldLink.object.PK();
+
       // array - 1:M , M:N
       if (linkVal.filter) {
          return (
-            linkVal.filter(
-               (val) => (val.uuid || val.id || val) == linkCursor.id
-            ).length > 0
+            linkVal.filter((val) => (val.id || val[PK] || val) == linkCursor.id)
+               .length > 0
          );
       } else {
-         return (linkVal.uuid || linkVal.id || linkVal) == linkCursor.id;
+         return (linkVal.id || linkVal[PK] || linkVal) == linkCursor.id;
       }
    }
 


### PR DESCRIPTION
…s into a bound data collection after the records are updated. It happens because this is a single record update and we are trying to determine if it should be inserted into a bound data collection. To do so we would simply insert the record into the data collection without the need of a database query (in other cases where a connected field was updated we need to query the database). So now before we insert the updated record we check to make sure it meets the filter requirements.